### PR TITLE
Relative image paths.

### DIFF
--- a/ALL.md
+++ b/ALL.md
@@ -2705,7 +2705,7 @@ differ in a SOLE? In what ways can we unite that fundamental, passionate
 human characteristic of curiosity and self-organizing back into our
 Learning Environments?
 
-![image](../images/sole-u.jpg)
+![image](images/sole-u.jpg)
 
 
 

--- a/introduction.md
+++ b/introduction.md
@@ -286,7 +286,7 @@ they’re actually really important. So if we pay attention to all these,
 every little thing matters, and this is how I do it. I try to be very
 mindful in all interactions.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/talking.jpg)
+![image](images/talking.jpg)
 
 *How do you do peeragogy? Can you think of examples that worked well,
 and others that didn’t work as well?*
@@ -333,7 +333,7 @@ insecure, because they really do not know how or what they want to do.
 So, that process of making decisions together becomes very rich and
 meaningful.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/footprints.jpg)
+![image](images/footprints.jpg)
 
 * * * * *
 
@@ -538,7 +538,7 @@ rights dedicated to the Public Domain under the Creative Commons Zero
 license. You can view the license online at
 <https://creativecommons.org/publicdomain/zero/1.0/>.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/napkin-drawings.jpg)
+![image](images/napkin-drawings.jpg)
 
 [^1]: Schoenfeld, A. H. (1987). What’s all the fuss about metacognition?
     In A. H. Schoenfeld (Ed.), Cognitive science and mathematics

--- a/pattern-carrying.md
+++ b/pattern-carrying.md
@@ -18,8 +18,8 @@ do, since we all have limited time and energy.
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/antifragility.png) **Antifragility**: each person’s potential can only be realized if people take on enough, but not too much.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/independence.png) **Independence**: in a peeragogy context, it is often impossible to delegate work to others.
+> ![image](images/antifragility.png) **Antifragility**: each person’s potential can only be realized if people take on enough, but not too much.  
+> ![image](images/independence.png) **Independence**: in a peeragogy context, it is often impossible to delegate work to others.
 
 ### Problem 
 
@@ -102,7 +102,7 @@ imbalance at Wikipedia <span class="citation">\[1,9\]</span>, it will be
 important to do whatever it takes to make women and girls welcome, not
 least because this is a significant factor in boosting our .
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/ladies-hall.jpg)  
+![image](images/ladies-hall.jpg)  
 *Ladies Hall: Queens College, North Carolina.*
 
 ### What’s Next in the Peeragogy Project

--- a/pattern-heartbeat.md
+++ b/pattern-heartbeat.md
@@ -19,8 +19,8 @@ efficient.
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/differentiation.png) **Differentiation**: the time we spend together isn’t all equally meaningful.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/entropy.png) **Entropy**: something needs to hold the project together, or it will fall apart.
+> ![image](images/differentiation.png) **Differentiation**: the time we spend together isn’t all equally meaningful.  
+> ![image](images/entropy.png) **Entropy**: something needs to hold the project together, or it will fall apart.
 
 ### Problem 
 
@@ -79,7 +79,7 @@ other shorter cycles. Each day a highly-vetted Featured Article appears
 on the front page of Wikipedia, and is circulated to a special-purpose
 mailing list.[^fn4]<sup>,</sup>[^fn5]<sup>,</sup>[^fn6] articles for deletion lasts at least seven days.[^fn7]
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/kapisa.jpg)  
+![image](images/kapisa.jpg)  
 *University Farm: al-Biruni University, Kapisa province, Afghanistan.*
 
 ### Example 2 

--- a/pattern-newcomer.md
+++ b/pattern-newcomer.md
@@ -16,8 +16,8 @@ new to a topic, or to something about the topic.
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/individuation.png) **Individuation**: each person learning optimally is what’s best for the community.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/mutuality.png) **Mutuality**: our individuality does not isolate us from one another, but draws us together.
+> ![image](images/individuation.png) **Individuation**: each person learning optimally is what’s best for the community.  
+> ![image](images/mutuality.png) **Mutuality**: our individuality does not isolate us from one another, but draws us together.
 
 ### Problem 
 
@@ -93,7 +93,7 @@ the claim that “novice users learn the rules and conventions for
 contributing both through observation and direct coaching from more
 knowledgeable others” <span class="citation">\[2\]</span>.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/The_Science_Laboratory.jpg)  
+![image](images/The_Science_Laboratory.jpg)  
 *Science Hall: Aspatria Agricultural College, Aspatria, Cumberland, UK*
 
 ### Example 2 

--- a/pattern-peeragogy.md
+++ b/pattern-peeragogy.md
@@ -29,8 +29,8 @@ form of friendly competition, in which *the best craftmanship wins*
 ### Forces
 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/threshold.png) **Threshold**: inclusiveness and specificity are in tension.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/trust.png) **Trust**: is only built through sharing and reciprocity.
+> ![image](images/threshold.png) **Threshold**: inclusiveness and specificity are in tension.  
+> ![image](images/trust.png) **Trust**: is only built through sharing and reciprocity.
 
 ### Problem
 
@@ -103,7 +103,7 @@ employees. For comparison, the 6<sup>th</sup> (Amazon) and 8<sup>th</sup> (QQ) m
 popular websites are run by companies with over 200K and 28K employees,
 respectively.[^fnref3]<sup>,</sup>[^fnref4]<sup>,</sup>[^fnref5]<sup>,</sup>[^fnref6]
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/Space_Surveillance_Telescope.jpg)
+![image](images/Space_Surveillance_Telescope.jpg)
 *Observatory : Space Surveillance Telescope, New Mexico.*
 
 ### Example 2 

--- a/pattern-reduce.md
+++ b/pattern-reduce.md
@@ -16,9 +16,9 @@ building on the work of others.
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/derivative.png) **Derivative**: you don’t have to do everything yourself!  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/sensemaking.png) **Sensemaking**: resources are useful only when you can make sense of them.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/sharing.png) **Sharing**: your understanding gains robustness when you share with others.
+> ![image](images/derivative.png) **Derivative**: you don’t have to do everything yourself!  
+> ![image](images/sensemaking.png) **Sensemaking**: resources are useful only when you can make sense of them.  
+> ![image](images/sharing.png) **Sharing**: your understanding gains robustness when you share with others.
 
 ### Problem 
 
@@ -48,7 +48,7 @@ by the keywords in the pattern’s title:
     going to have to do anyway” from everyone involved.
 -   *Recycle* what you’ve created in new connections and relationships.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/Duchamp_Fountaine.jpg)  
+![image](images/Duchamp_Fountaine.jpg)  
 *A paradigmatic example of found-art. “Fountain by R. Mutt, Photograph by Alfred Stieglitz, THE EXHIBIT REFUSED BY THE INDEPENDENTS”.*
 
 ### Rationale 

--- a/pattern-roadmap.md
+++ b/pattern-roadmap.md
@@ -20,9 +20,9 @@ conversations and joint activities.
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/variety.png) **Variety**: people have different goals and interests in mind.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/clarity.png) **Clarity**: some goals may be quite specific, and some rather vague.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/coherence.png) **Coherence**: only some of these goals will be well-aligned.
+> ![image](images/variety.png) **Variety**: people have different goals and interests in mind.  
+> ![image](images/clarity.png) **Clarity**: some goals may be quite specific, and some rather vague.  
+> ![image](images/coherence.png) **Coherence**: only some of these goals will be well-aligned.
 
 ### Problem 
 
@@ -109,7 +109,7 @@ facilitators to gather at a University Hall. Whereas there is strength
 in numbers, there is leverage in organization. This is what the
 <span><span>Roadmap</span></span> provides.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/alabama-small.jpg)  
+![image](images/alabama-small.jpg)  
 *President's Residence, University of Alabama.*
 
 ### What’s Next in the Peeragogy Project

--- a/pattern-scrapbook.md
+++ b/pattern-scrapbook.md
@@ -16,9 +16,9 @@ Next” steps associated with some of the patterns.
 
 ### Forces 
 
-> ![image](fire) **Attention**: due to limited energy, we need to ask: where should we set the focus?
-> ![image](whale) **Interest**: new experiences catch our attention.
-> ![image](museum) **Meaning**: shared history makes things meaningful.
+> ![image](images/attention.png) **Attention**: due to limited energy, we need to ask: where should we set the focus?
+> ![image](images/interest.png) **Interest**: new experiences catch our attention.
+> ![image](images/meaning.png) **Meaning**: shared history makes things meaningful.
 
 ### Problem 
 
@@ -98,7 +98,7 @@ fine-grained changes to articles.[^fn5]<sup>,</sup>[^fn6]
 typically discussed at the Village Pump, and there are mechanisms in
 place for settling disputes.[^7^]<sup>,</sup>[^fn8]
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/ChristsPieces.jpg)  
+![image](images/ChristsPieces.jpg)  
 *Park: Christ’s Pieces, Cambridge, UK*
 
 ### Example 2 

--- a/pattern-specific.md
+++ b/pattern-specific.md
@@ -20,8 +20,8 @@ it to be feasible.
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/difficulty.png) **Difficulty**: bringing about meaningful change is often hard work.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/inertia.png) **Inertia**: when things are hard we may feel stuck, wring our hands, or preach to the choir.
+> ![image](images/difficulty.png) **Difficulty**: bringing about meaningful change is often hard work.  
+> ![image](images/inertia.png) **Inertia**: when things are hard we may feel stuck, wring our hands, or preach to the choir.
 
 ### Problem 
 
@@ -79,7 +79,7 @@ idea, but hard to do anything about.[^fn1]
 practice, many Wikipedians contribute to the mission by working on
 <span><span>A specific project</span></span>.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/Ruin_Academy_Dorm.jpg)
+![image](images/Ruin_Academy_Dorm.jpg)
 *Dormitory, Ruin Academy, Taipei, Taiwan.*
 
 Within Wikipedia, these are known as “WikiProjects.”[^fn2]<sup>,</sup>^[^fn3]

--- a/pattern-wrapper.md
+++ b/pattern-wrapper.md
@@ -17,9 +17,9 @@ project with more than a handful of participants. How do you manage?
 
 ### Forces 
 
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/interface.png) **Interface**: the project shows people how they can use it.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/familiar.png) **Familiarity**: the leader/follower dichotomy is easy to understand.  
-> ![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/equity.png) **Equity**: peeragogy aims for fairness.
+> ![image](images/interface.png) **Interface**: the project shows people how they can use it.  
+> ![image](images/familiar.png) **Familiarity**: the leader/follower dichotomy is easy to understand.  
+> ![image](images/equity.png) **Equity**: peeragogy aims for fairness.
 
 ### Problem 
 
@@ -34,7 +34,7 @@ there is also a problem with missing information. If key skills are not
 shared, they can quickly become bottlenecks (see <span><span>Carrying
 capacity</span></span>).
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/dashboard_design.jpg)
+![image](images/dashboard_design.jpg)
 *Design for a Peeragogy project dashboard (sketch by Amanda Lyons, prototype by Fabrizio Terzi).*
 
 ### Solution 

--- a/patterns.md
+++ b/patterns.md
@@ -104,7 +104,7 @@ plan; their plan is just to see what develops. You can see here how
 peeragogy patterns often break down further into individual micro-steps:
 we’ll say more about that shortly.
 
-![image](../images/pattern-language.jpg)
+![image](images/pattern-language.jpg)
 [can this chart be larger? Looks very small in text]
 The subsequent main sections of this book –
 [*Convene*](http://peeragogy.org/convene/),

--- a/practice.md
+++ b/practice.md
@@ -15,7 +15,7 @@ fully conform to our chosen tacitly-familiar territory of *peeragogy*.
 To be clear, peeragogy is for *any group of people who want to learn
 anything*.[^fn1]
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/wisconsin-map.jpg)  
+![image](images/wisconsin-map.jpg)  
 *A prototypical university. Caption reads: Wisconsin State University, Madison, Wis. 1879. Inset captions describe the pictured buildings: Ladies Hall, South Dormitory, University Hall, Assembly Halls & Library, North Dormitory, Science Hall, President’s Residence, University Farm, and Washburn Observatory. Public domain.*
 
 Despite thinking about learning and adaptation that may take place far
@@ -151,7 +151,7 @@ newcomer found <span><span>A specific project</span></span> to start
 with, and scaffolded her knowledge and contributions from that
 foundation.
 
-![image](https://raw.githubusercontent.com/Peeragogy/Peeragogy.github.io/master/images/pattern-connections.png)  
+![image](images/pattern-connections.png)  
   
 |overview of problems and solutions in the pattern catalog|
 |---------------------------------------------------------|

--- a/sole.md
+++ b/sole.md
@@ -39,7 +39,7 @@ differ in a SOLE? In what ways can we unite that fundamental, passionate
 human characteristic of curiosity and self-organizing back into our
 Learning Environments?
 
-![image](../images/sole-u.jpg)
+![image](images/sole-u.jpg)
 
 
 


### PR DESCRIPTION
This might break the images of the GitHub Jekyll Pages, but shouldn't. Can't test in advance, so please check after merging if the images on the website are still fine. Belongs to [Peeragogy/peeragogy-handbook#6](https://github.com/Peeragogy/peeragogy-handbook/issues/6).